### PR TITLE
Fix for #58

### DIFF
--- a/javascript/nevysha-cozy-nest.js
+++ b/javascript/nevysha-cozy-nest.js
@@ -624,6 +624,8 @@ async function loadVersionData() {
     document.querySelector('#nevysha-version-info').insertAdjacentHTML('afterbegin', p)
     //hide update button
     document.querySelector('#nevyui_update_btn').style.display = "none";
+    //add version info to the bottom-right corner (no update available)
+    document.getElementsByClassName("versions")[0].innerHTML += '⠀•⠀Cozy Nest: <a href="https://github.com/Nevysha/Cozy-Nest" target="_blank">⠀v' + current_version_data.version + '</a>';
   }
   else {
     //local version is older than remote version
@@ -633,6 +635,9 @@ async function loadVersionData() {
 
     //set fill color of .nevysha-btn-menu-wrapper > button > svg to red
     document.querySelector('#nevyui_update_info > svg').style.fill = "red";
+	
+    //add version info to the bottom-right corner with a notice about an update
+    document.getElementsByClassName("versions")[0].innerHTML += '⠀•⠀Cozy Nest:⠀<span style="color: #f9e02d; text-decoration: underline;" title="Nevysha\'s Cozy Nest Update Available! Latest version: v' + remote_version_data.version + '.\nView update info in the top-right corner for more details.">v' + current_version_data.version + '</span>';
   }
 
 }

--- a/style.css
+++ b/style.css
@@ -1438,3 +1438,21 @@ canvas.nevysha {
     line-height: var(--line-sm)!important;
     font-family: monospace!important;
 }
+
+/*Fix for generation info size*/
+
+.infotext {
+    max-height: 200px;
+    overflow-y: auto;
+}
+.infotext::-webkit-scrollbar {
+    width: 5px;
+}
+
+.infotext::-webkit-scrollbar-thumb {
+    background-color: var(--ae-primary-color);
+    border-radius: 20px;
+}
+.infotext::-webkit-scrollbar-track {
+    background-color: transparent;
+}


### PR DESCRIPTION
Fixes the issue when generation info will overlap generated pictures by limiting generation info size and adding overflow to it when it's too big
![StyleTest](https://github.com/Nevysha/Cozy-Nest/assets/1958477/ad67e61c-a267-4914-9b3a-0ea4d5882863)
