### PR TITLE
Fix footer selector

### DIFF
--- a/javascript/nevysha-cozy-nest.js
+++ b/javascript/nevysha-cozy-nest.js
@@ -1498,7 +1498,7 @@ const recalcOffsetFromMenuHeight = () => {
 
   const tabs = document.getElementById('tabs');
 
-  const footer = document.querySelector('#footer #footer');
+  const footer = document.querySelector('footer');
 
   // //get value of the css var var(--layout-gap);
   // const layoutGap = getComputedStyle(document.documentElement).getPropertyValue('--layout-gap');


### PR DESCRIPTION
This is a small fix to get the correct `footer` element in `recalcOffsetFromMenuHeight()` method.
The previous selector was causing the element to be null which caused the application to halt the loading process.