### PR TITLE
Fix UI loading hack

### DIFF
--- a/cozy-nest-client/main/tweaks/various-tweaks.js
+++ b/cozy-nest-client/main/tweaks/various-tweaks.js
@@ -224,7 +224,7 @@ export const recalcOffsetFromMenuHeight = () => {
 export const wrapDataGenerationInfo = ({prefix}) => {
   // Get the generation info container
   const previewBlocks = document.querySelectorAll(`#tab_${prefix} div#${prefix}_results > *:not(#${prefix}_results)`);
-  const generationInfoContainer = previewBlocks[1].querySelectorAll(`#html_info_${prefix}, #html_log_${prefix}`);
+  const generationInfoContainer = previewBlocks[0].querySelectorAll(`#html_info_${prefix}, #html_log_${prefix}`);
 
   // Create the new container element and add a class for styling
   const wrapper = document.createElement('div');
@@ -244,13 +244,13 @@ export const wrapDataGenerationInfo = ({prefix}) => {
   generationInfoContainer.forEach((el) => wrapper.appendChild(el));
 
   // Add the wrapper container at the end of the previewBlocks[1] container
-  previewBlocks[1].appendChild(wrapper);
+  previewBlocks[0].appendChild(wrapper);
 
   // Hide the generation info container by default
   generationInfoContainer.forEach((el) => el.style.display = 'none');
 
   // Remove the inline style from the previewBlocks[1] container
-  previewBlocks[1].style = "";
+  previewBlocks[0].style = "";
 }
 
 export function wrapSettings({prefix}) {


### PR DESCRIPTION
Fixes an error
"Cannot read properties of undefined (reading 'querySelectorAll')" During loading process.

I don't know how it was before 1.6.x update, but currently there is only 1 element returned by the selector. Taking 0 one seems to be fixes the issue.

----

Generation works, but there is an error in console while loading networks
```
ERROR:    Exception in ASGI application
OverflowError: int too big to convert
TypeError: Integer exceeds 64-bit range
```
This error happens when it tries to load data using this url: http://127.0.0.1:7860/cozy-nest/extra_networks/full
Not sure about this one. Probably some api change?